### PR TITLE
Single quotes around version number.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "5.0.1.5-SNAPSHOT"
+VERSION = '5.0.1.5-SNAPSHOT'
 
 setup(
     name="Marvin",


### PR DESCRIPTION
Due to https://github.com/MissionCriticalCloud/organization_utils/pull/48
