### PR TITLE
Method from test_cancel_host_migration test

### DIFF
--- a/marvin/lib/utils.py
+++ b/marvin/lib/utils.py
@@ -383,3 +383,22 @@ def validateState(apiclient, obj, state, timeout=600, interval=5):
 
 def key_maps_to_value(dictionary, key):
     return key in dictionary and dictionary[key] is not None
+
+
+def wait_until(retry_interval=2, no_of_times=2, callback=None, *callback_args):
+    """ Utility method to try out the callback method at most no_of_times with a interval of retry_interval,
+        Will return immediately if callback returns True. The callback method should be written to return a list of values first being a boolean """
+
+    if callback is None:
+        raise ("Bad value for callback method !")
+
+    wait_result = False
+    for i in range(0,no_of_times):
+        time.sleep(retry_interval)
+        wait_result, return_val = callback(*callback_args)
+        if not(isinstance(wait_result, bool)):
+            raise ("Bad parameter returned from callback !")
+        if wait_result :
+            break
+
+    return wait_result, return_val


### PR DESCRIPTION
Backport from ACS, cancel host migration test added a method to Marvin.

See: https://github.com/MissionCriticalCloud/cosmic-core/pull/174
