### PR TITLE
Account for temporary empty template.status

### DIFF
--- a/marvin/lib/base.py
+++ b/marvin/lib/base.py
@@ -1270,27 +1270,24 @@ class Template:
             if isinstance(template_response, list):
 
                 template = template_response[0]
-                # If template is ready,
-                # template.status = Download Complete
-                # Downloading - x% Downloaded
-                # Error - Any other string
                 if template.status == 'Download Complete':
                     break
 
                 elif 'Downloaded' in template.status:
                     time.sleep(interval)
 
+                elif not template.status.strip(): # status is empty string
+                    time.sleep(interval)
+
                 elif 'Installing' not in template.status:
-                    raise Exception(
-                        "Error in downloading template: status - %s" %
-                        template.status)
+                    raise Exception("Error in downloading template: status - %s" % template.status)
 
             elif timeout == 0:
                 break
 
             else:
                 time.sleep(interval)
-                timeout = timeout - interval
+                timeout -= interval
         return
 
     def updatePermissions(self, apiclient, **kwargs):

--- a/marvin/lib/utils.py
+++ b/marvin/lib/utils.py
@@ -132,7 +132,7 @@ def random_gen(id=None, size=6, chars=string.ascii_uppercase + string.digits):
 
 def cleanup_resources(api_client, resources, logger=None):
     if logger is not None:
-        logger.debug("Cleaing up all resources: %s" % resources)
+        logger.debug("Cleaning up all resources: %s" % resources)
     """Delete resources"""
     for obj in resources:
         if logger is not None:


### PR DESCRIPTION
I'm seeing that, after registering and while downloading, the template status string is empty. Furthermore, this state is temporary and does eventually become something expected. The `Template.download(..)` method was not equipped to deal with that. 
